### PR TITLE
Cope with empty configuration by silently exporting no bindings

### DIFF
--- a/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceModule.scala
+++ b/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceModule.scala
@@ -15,7 +15,7 @@ class LettuceModule extends SimpleModule((_: Environment, configuration: Configu
 
   import scala.collection.JavaConverters._
 
-  val defaultCacheName = configuration.underlying.getString("play.cache.defaultCache")
+  val defaultCacheName = Try(configuration.underlying.getString("play.cache.defaultCache")).toOption
   val bindCaches = Try(configuration.underlying.getStringList("play.cache.bindCaches")) match {
     case Success(v) => v.asScala
     case Failure(e) =>
@@ -42,11 +42,11 @@ class LettuceModule extends SimpleModule((_: Environment, configuration: Configu
     )
   }
 
-  Seq(
+  defaultCacheName.map(defaultCacheName => Seq(
     bind[LettuceCacheApi].to(new LettuceClientProvider(configuration, defaultCacheName)),
     bind[AsyncCacheApi].to(new LettuceClientProvider(configuration, defaultCacheName)),
     bind[SyncCacheApi].to(new SyncWrapperProvider(configuration, defaultCacheName)),
     bind[JavaAsyncCacheApi].to(new JavaAsyncWrapperProvider(configuration, defaultCacheName)),
     bind[JavaSyncCacheApi].to(new JavaSyncWrapperProvider(configuration, defaultCacheName))
-  ) ++ bindCaches.flatMap(bindCache)
+  )).getOrElse(Nil) ++ bindCaches.flatMap(bindCache)
 })

--- a/src/test/scala/com/github/simonedeponti/play26lettuce/LettuceSpec.scala
+++ b/src/test/scala/com/github/simonedeponti/play26lettuce/LettuceSpec.scala
@@ -48,6 +48,7 @@ class LettuceSpec extends Specification {
   private val configuration = play.api.Configuration.from(
     configurationMap
   )
+  private val emptyConfiguration = play.api.Configuration.empty
 
   private val modules = play.api.inject.Modules.locate(environment, configuration)
 
@@ -64,6 +65,14 @@ class LettuceSpec extends Specification {
       val bindings = lettuceModule.bindings(environment, configuration)
 
       bindings.size mustNotEqual 0
+    }
+
+    "provide no bindings with empty configuration" in {
+      val lettuceModule = modules.find { module => module.isInstanceOf[LettuceModule] }.get.asInstanceOf[LettuceModule]
+
+      val bindings = lettuceModule.bindings(environment, emptyConfiguration)
+
+      bindings.size mustEqual 0
     }
   }
 


### PR DESCRIPTION
The README is nice and detailed about the required default configuration. However, it's kinda annoying to get:

> `com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'play.cache.defaultCache'`

in cases where the configuration isn't set up. What do you think about allowing empty configuration by exporting no bindings?

The other common way I've seen is to add a `reference.conf` with some defaults, but we'd then have to decide on a defaultCache name, which we might want to avoid.