### PR TITLE
Add get/set/remove multi-key support

### DIFF
--- a/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceCacheApi.scala
+++ b/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceCacheApi.scala
@@ -1,5 +1,6 @@
 package com.github.simonedeponti.play26lettuce
 
+import akka.Done
 import play.api.cache.AsyncCacheApi
 
 import scala.concurrent.Future
@@ -31,4 +32,28 @@ trait LettuceCacheApi extends AsyncCacheApi {
     * @return A [[scala.concurrent.Future]] wrapping the result (unlike a get, there is always a result, either fetched or computed)
     */
   def javaGetOrElseUpdate[A](key: String, expiration: Duration)(orElse: => Future[A]): Future[A]
+
+  /** A multi-key get method
+   *
+   * @param keys A sequence of keys to get
+   * @tparam T The type of the value
+   * @return A [[scala.concurrent.Future]] wrapping a [[scala.collection.Seq]] of [[scala.Option]]s of the object being returned, one for each requested key
+   */
+  def getAll[T <: AnyRef](keys: Seq[String]): Future[Seq[Option[T]]]
+
+  /** A multi-key remove method
+   *
+   * @param keys A sequence to keys to remove
+   * @return A [[scala.concurrent.Future]] that indicates when the keys have been removed
+   */
+  def remove(keys: Seq[String]): Future[Done]
+
+  /** A multi-key set method
+   *
+   * Sets the keys to their respective values, with no expiry. Replaces existing values with new values.
+   *
+   * @param keyValues key-value pairs
+   * @return A [[scala.concurrent.Future]] that indicates when the keys have been set
+   */
+  def setAll(keyValues: Map[String, AnyRef]): Future[Done]
 }

--- a/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceClient.scala
+++ b/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceClient.scala
@@ -1,18 +1,20 @@
 package com.github.simonedeponti.play26lettuce
 
-import javax.inject.{Inject, Singleton}
+import java.util
 
+import javax.inject.{ Inject, Singleton }
 import akka.Done
 
 import scala.reflect.ClassTag
 import scala.compat.java8.FutureConverters._
 import akka.actor.ActorSystem
-import io.lettuce.core.{RedisClient, SetArgs}
+import io.lettuce.core.{ KeyValue, RedisClient, RedisFuture, SetArgs }
 import io.lettuce.core.api.async.RedisAsyncCommands
 import play.api.Configuration
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.mutable
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 
 
@@ -70,6 +72,14 @@ class LettuceClient @Inject() (val system: ActorSystem, val configuration: Confi
     javaGet[T](key)
   }
 
+  override def getAll[T <: AnyRef](keys: Seq[String]): Future[Seq[Option[T]]] = {
+    commands.mget(keys.map(key => s"$name::$key"): _*).toScala.map(_.asScala.map {
+      case data: KeyValue[String, AnyRef] if data.hasValue => Some(data.getValue).asInstanceOf[Option[T]]
+      case data: KeyValue[String, AnyRef] if !data.hasValue => None
+      case null => None
+    })
+  }
+
   override def getOrElseUpdate[A](key: String, expiration: Duration)(orElse: => Future[A])(implicit ctag: ClassTag[A]): Future[A] = {
     javaGetOrElseUpdate[A](key, expiration)(orElse)
   }
@@ -88,8 +98,22 @@ class LettuceClient @Inject() (val system: ActorSystem, val configuration: Confi
     doSet(key, value, expiration).map(_ => Done)
   }
 
+  override def setAll(keyValues: Map[String, AnyRef]): Future[Done] = {
+    commands.mset(
+      mutable.Map(
+        keyValues.map {
+          case (key, value) => (s"$name::$key", value)
+        }.toSeq: _*
+      ).asJava
+    ).toScala.map(_ => Done)
+  }
+
   override def remove(key: String): Future[Done] = {
     commands.del(s"$name::$key").toScala.map(_ => Done)
+  }
+
+  override def remove(keys: Seq[String]): Future[Done] = {
+    commands.del(keys.map(key => s"$name::$key"): _*).toScala.map(_ => Done)
   }
 
   override def removeAll(): Future[Done] = {
@@ -103,5 +127,4 @@ class LettuceClient @Inject() (val system: ActorSystem, val configuration: Confi
       }
     )
   }
-
 }


### PR DESCRIPTION
Fixes #3 by adding the following to `LettuceCacheApi` and implementing them in `LettuceClient`:

- `def getAll[T <: AnyRef](keys: Seq[String]): Future[Seq[Option[T]]]`
- `def setAll(keyValues: Map[String, AnyRef]): Future[Done]`
- `def remove(keys: Seq[String]): Future[Done]`

Tests included.

The only real wrinkle is that these methods only accept `AnyRef`, not `Any`, because the underlying command is, for example, `RedisFuture<List<KeyValue<K, V>>> mget(K... keys)`, so we can only genericize over Object descendants (~= AnyRef).