### PR TITLE
Implement removeAll() in terms of SCAN/DEL

### DIFF
--- a/src/test/scala/com/github/simonedeponti/play26lettuce/LettuceSpec.scala
+++ b/src/test/scala/com/github/simonedeponti/play26lettuce/LettuceSpec.scala
@@ -278,6 +278,30 @@ class LettuceSpec extends Specification {
         result_fin must beAnInstanceOf[Done].await
       }
     }
+
+    "removeAll should remove a lot of keys successfully" in {
+      implicit ee: ExecutionEnv => {
+        val cacheApi = injector.instanceOf(play.api.inject.BindingKey(classOf[LettuceCacheApi]))
+
+        val result = for {
+          _ <- cacheApi.set("foo1", "bar")
+          _ <- cacheApi.set("foo2", "bar")
+          _ <- cacheApi.set("foo3", "bar")
+          _ <- cacheApi.set("foo4", "bar")
+          _ <- cacheApi.set("foo5", "bar")
+          _ <- cacheApi.set("foo6", "bar")
+          _ <- cacheApi.set("foo7", "bar")
+          _ <- cacheApi.set("foo8", "bar")
+          _ <- cacheApi.set("foo9", "bar")
+          _ <- cacheApi.set("foo10", "bar")
+          _ <- cacheApi.set("foo11", "bar")
+          _ <- cacheApi.set("foo12", "bar")
+          removed <- cacheApi.removeAll()
+        } yield removed
+
+        result must beAnInstanceOf[Done].await
+      }
+    }
   }
 
   "SyncCacheApi" should {


### PR DESCRIPTION
Fixes #4 

A strawman implementation of option 2 in #4, that keeps the key-prefix named cache implementation intact.

The iteration and delete futures will proceed in parallel, which is pretty nice. I'd anticipate there shouldn't be much difference between the server-time overhead in `KEYS` and a `SCAN MATCHES`; the main difference will be in network time, and the asynchronous nature of the scan (but that's actually a virtue because it allows other work on the instance to proceed as it happens).

Also, has more constant memory requirements than the previous version, which would probably blow out on truely large keyspaces (as it loaded every key into memory before running DEL). Also, it now runs DEL with multiple keys so there'll be less round-trips.

This PR might be a bit premature if we're going with option 1 in #4, but I know from hard-won experience how painful it is to try to debug server pauses with `LATENCY DOCTOR` etc. so I'll probably use this in my own fork for the meantime.