### PR TITLE
Inject the AkkaCodec rather than instantiating inside LettuceClient

### DIFF
--- a/src/main/scala/com/github/simonedeponti/play26lettuce/AkkaCodec.scala
+++ b/src/main/scala/com/github/simonedeponti/play26lettuce/AkkaCodec.scala
@@ -2,6 +2,7 @@ package com.github.simonedeponti.play26lettuce
 
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
+import javax.inject.Inject
 
 import akka.actor.ActorSystem
 import akka.serialization.SerializationExtension
@@ -17,7 +18,7 @@ import io.lettuce.core.codec.RedisCodec
   *
   * @param system Akka's active actor system
   */
-class AkkaCodec(val system: ActorSystem) extends RedisCodec[String, AnyRef] {
+class AkkaCodec @Inject() (val system: ActorSystem) extends RedisCodec[String, AnyRef] {
 
   private val serialization = SerializationExtension(system)
   private val charset = Charset.forName("UTF-8")

--- a/src/main/scala/com/github/simonedeponti/play26lettuce/BaseClientProvider.scala
+++ b/src/main/scala/com/github/simonedeponti/play26lettuce/BaseClientProvider.scala
@@ -21,6 +21,7 @@ abstract class BaseClientProvider[T] extends Provider[T] {
 
   @Inject protected var injector: Injector = _
   @Inject protected var actorSystem: ActorSystem = _
+  @Inject protected var codec: AkkaCodec = _
 
   /** The execution context that the cache uses to execute futures **/
   protected def ec: ExecutionContext = configuration.getOptional[String]("play.cache.dispatcher").map(actorSystem.dispatchers.lookup(_)).getOrElse(injector.instanceOf[ExecutionContext])
@@ -31,6 +32,6 @@ abstract class BaseClientProvider[T] extends Provider[T] {
     * @return An instance of [[com.github.simonedeponti.play26lettuce.LettuceCacheApi]]
     */
   protected def getLettuceApi(name: String): LettuceCacheApi = {
-    new LettuceClient(actorSystem, configuration, name)(ec)
+    new LettuceClient(codec, configuration, name)(ec)
   }
 }

--- a/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceClient.scala
+++ b/src/main/scala/com/github/simonedeponti/play26lettuce/LettuceClient.scala
@@ -5,7 +5,6 @@ import akka.Done
 
 import scala.reflect.ClassTag
 import scala.compat.java8.FutureConverters._
-import akka.actor.ActorSystem
 import io.lettuce.core.{KeyValue, RedisClient, SetArgs}
 import io.lettuce.core.api.async.RedisAsyncCommands
 import play.api.Configuration
@@ -18,19 +17,17 @@ import scala.util.Try
 
 /** The base implementation of [[com.github.simonedeponti.play26lettuce.LettuceCacheApi]].
   *
-  * @param system The current Akka actor system
+  * @param codec A lettuce RedisCodec that can be used to serialize AnyRef
   * @param configuration The application configuration
   * @param name The cache name (or "default" if missing)
   * @param ec The execution context to use
   */
 @Singleton
-class LettuceClient @Inject() (val system: ActorSystem, val configuration: Configuration, val name: String = "default")
+class LettuceClient @Inject() (protected val codec: AkkaCodec, val configuration: Configuration, val name: String = "default")
                               (implicit val ec: ExecutionContext) extends LettuceCacheApi {
 
   /** The [[io.lettuce.core.RedisClient]] instance that represents the connection to Redis **/
   private val client: RedisClient = RedisClient.create(configuration.get[String](s"lettuce.$name.url"))
-  /** The serialization codec (an [[com.github.simonedeponti.play26lettuce.AkkaCodec]] instance) **/
-  private val codec = new AkkaCodec(system)
   /** The redis commands bound to the specific client and encoder **/
   private val commands: RedisAsyncCommands[String, AnyRef] = client.connect(codec).async()
 


### PR DESCRIPTION
Fixes #8 

Allows the codec to be an alternative implementation of AkkaCodec